### PR TITLE
StatsdClient can now be given a postfix to append to all logging messages

### DIFF
--- a/StatsdClientTests/StatsdExtensionsTests.cs
+++ b/StatsdClientTests/StatsdExtensionsTests.cs
@@ -12,48 +12,45 @@ namespace StatsdClientTests
   [TestClass]
   public class StatsdExtensionsTests
   {
-    private Mock<IOutputChannel> _outputChannel;
+    private FakeOutputChannel _channel;
     private Statsd _statsd;
     private TestData _testData;
+    TaskCompletionSource<int> _tcs;
 
     [TestInitialize]
     public void Initialise()
     {
-      _outputChannel = new Mock<IOutputChannel>();
-      _statsd = new Statsd("localhost", 12000, outputChannel : _outputChannel.Object);
+      _channel = new FakeOutputChannel();
+      _statsd = new Statsd("localhost", 12000, outputChannel : _channel);
       _testData = new TestData();
     }
 
     [TestMethod]
     public void count_SendToStatsd_Success()
-    {
-      _outputChannel.Setup(p => p.Send("foo.bar:1|c")).Verifiable();
+    {        
       _statsd.count().foo.bar += 1;
-      _outputChannel.VerifyAll();
+      Assert.AreEqual<string>("foo.bar:1|c", _channel.LineSent);
     }
 
     [TestMethod]
     public void gauge_SendToStatsd_Success()
     {
-      _outputChannel.Setup(p => p.Send("foo.bar:1|g")).Verifiable();
       _statsd.gauge().foo.bar += 1;
-      _outputChannel.VerifyAll();
+      Assert.AreEqual<string>("foo.bar:1|g", _channel.LineSent);
     }
 
     [TestMethod]
     public void timing_SendToStatsd_Success()
-    {
-      _outputChannel.Setup(p => p.Send("foo.bar:1|ms")).Verifiable();
+    {      
       _statsd.timing().foo.bar += 1;
-      _outputChannel.VerifyAll();
+      Assert.AreEqual<string>("foo.bar:1|ms", _channel.LineSent);
     }
 
     [TestMethod]
     public void count_AddNamePartAsString_Success()
     {
-      _outputChannel.Setup(p => p.Send("foo.bar:1|ms")).Verifiable();
       _statsd.timing().foo._("bar")._ += 1;
-      _outputChannel.VerifyAll();
+      Assert.AreEqual<string>("foo.bar:1|ms", _channel.LineSent);
     }
   }
   


### PR DESCRIPTION
Also fixed the unit tests.  

The unit tests were completely broken due to the change to async
everywhere so they are now fixed and Moq is mostly eliminated in favor
of a simple stub object.

StatsdClient can now be given a postfix name which will be appended to
every stat.  If the Statsd Client object is given the prefix
"some.prefix" and the postfix "hostname" then using
client.LogGauge("mygauge", 1) will result in the gauge
"some.prefix.myguage.hostname" being sent to statsd.  The use case for
this feature is based on how Krux does monitoring, see presentation
here:
https://puppetlabs.com/presentations/puppet-camp-london-2014-how-measure-everything-million-metrics-second-minimal
